### PR TITLE
Update Makefile to avoid stopping docker compose twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,11 @@ start: ## Start all containers
 
 fresh:  ## Destroy & recreate all uing dev containers.
 	make stop
-	make destroy
 	make build
 	make start
 
 fresh-prod: ## Destroy & recreate all using prod containers.
 	make stop
-	make destroy
 	make build-prod
 	make start
 


### PR DESCRIPTION
`make destroy` is an alias of `make stop`. There is no need to call both.